### PR TITLE
fix: modem_isWireless block generates correct isWireless() call

### DIFF
--- a/src/renderer/engine/blockly/blocks/custom/modem.ts
+++ b/src/renderer/engine/blockly/blocks/custom/modem.ts
@@ -119,13 +119,12 @@ export const modemBlocks: Blocks = {
                     .appendField('modem');
                 this.setOutput(true, 'Boolean');
                 this.setStyle('modem_blocks');
-                this.setTooltip('Check if a channel is open on the modem');
+                this.setTooltip('Check if the modem is wireless');
             },
         },
         generator: (block, gen) => {
-            const channel = gen.valueToCode(block, 'CHANNEL', Order.NONE);
             const modem = gen.valueToCode(block, 'MODEM_PERIPHERAL', Order.NONE);
-            return [`${modem}.isOpen(${channel})`, Order.ATOMIC];
+            return [`${modem}.isWireless()`, Order.ATOMIC];
         }
     },
     'modem_getNamesRemote': {


### PR DESCRIPTION
Fixes #34

## Problem
The "modem is wireless" block was generating invalid Lua code. When exported, it produced:
```lua
nil.isOpen()
```

This happened because the `modem_isWireless` block generator was:
1. Trying to read a non-existent `CHANNEL` input
2. Calling `isOpen(channel)` instead of `isWireless()`

## Solution
- Removed the unused `channel` parameter from the generator
- Changed the method call from `isOpen(channel)` to `isWireless()`
- Updated the tooltip to accurately describe what the block checks

## Testing
- Build passes successfully
- The block now generates correct Lua code: `modem.isWireless()`