### PR TITLE
Fix Lua generation for terminal, lists, paintutils and window blocks

### DIFF
--- a/src/renderer/engine/blockly/blocks/custom/paintUtils.ts
+++ b/src/renderer/engine/blockly/blocks/custom/paintUtils.ts
@@ -21,7 +21,7 @@ export const paintUtilsBlocks: Blocks = {
         generator: (block, gen) => {
             const x = gen.valueToCode(block, 'X', Order.NONE);
             const y = gen.valueToCode(block, 'Y', Order.NONE);
-            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE);
             return `${gen.getIndent()}paintutils.drawPixel(${x}, ${y}, ${color})`;
         }
     },
@@ -50,7 +50,7 @@ export const paintUtilsBlocks: Blocks = {
             const y1 = gen.valueToCode(block, 'Y1', Order.NONE);
             const x2 = gen.valueToCode(block, 'X2', Order.NONE);
             const y2 = gen.valueToCode(block, 'Y2', Order.NONE);
-            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE);
             return `${gen.getIndent()}paintutils.drawLine(${x1}, ${y1}, ${x2}, ${y2}, ${color})`;
         }
     },
@@ -79,7 +79,7 @@ export const paintUtilsBlocks: Blocks = {
             const y1 = gen.valueToCode(block, 'Y1', Order.NONE);
             const x2 = gen.valueToCode(block, 'X2', Order.NONE);
             const y2 = gen.valueToCode(block, 'Y2', Order.NONE);
-            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE);
             return `${gen.getIndent()}paintutils.drawBox(${x1}, ${y1}, ${x2}, ${y2}, ${color})`;
         }
     },
@@ -108,7 +108,7 @@ export const paintUtilsBlocks: Blocks = {
             const y1 = gen.valueToCode(block, 'Y1', Order.NONE);
             const x2 = gen.valueToCode(block, 'X2', Order.NONE);
             const y2 = gen.valueToCode(block, 'Y2', Order.NONE);
-            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE);
             return `${gen.getIndent()}paintutils.drawFilledBox(${x1}, ${y1}, ${x2}, ${y2}, ${color})`;
         }
     },

--- a/src/renderer/engine/blockly/blocks/custom/paintUtils.ts
+++ b/src/renderer/engine/blockly/blocks/custom/paintUtils.ts
@@ -21,7 +21,7 @@ export const paintUtilsBlocks: Blocks = {
         generator: (block, gen) => {
             const x = gen.valueToCode(block, 'X', Order.NONE);
             const y = gen.valueToCode(block, 'Y', Order.NONE);
-            const color = block.getFieldValue('COLOR');
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
             return `${gen.getIndent()}paintutils.drawPixel(${x}, ${y}, ${color})`;
         }
     },
@@ -50,7 +50,7 @@ export const paintUtilsBlocks: Blocks = {
             const y1 = gen.valueToCode(block, 'Y1', Order.NONE);
             const x2 = gen.valueToCode(block, 'X2', Order.NONE);
             const y2 = gen.valueToCode(block, 'Y2', Order.NONE);
-            const color = block.getFieldValue('COLOR');
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
             return `${gen.getIndent()}paintutils.drawLine(${x1}, ${y1}, ${x2}, ${y2}, ${color})`;
         }
     },
@@ -79,7 +79,7 @@ export const paintUtilsBlocks: Blocks = {
             const y1 = gen.valueToCode(block, 'Y1', Order.NONE);
             const x2 = gen.valueToCode(block, 'X2', Order.NONE);
             const y2 = gen.valueToCode(block, 'Y2', Order.NONE);
-            const color = block.getFieldValue('COLOR');
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
             return `${gen.getIndent()}paintutils.drawBox(${x1}, ${y1}, ${x2}, ${y2}, ${color})`;
         }
     },
@@ -108,7 +108,7 @@ export const paintUtilsBlocks: Blocks = {
             const y1 = gen.valueToCode(block, 'Y1', Order.NONE);
             const x2 = gen.valueToCode(block, 'X2', Order.NONE);
             const y2 = gen.valueToCode(block, 'Y2', Order.NONE);
-            const color = block.getFieldValue('COLOR');
+            const color = gen.valueToCode(block, 'COLOR', Order.NONE) || 'colors.white';
             return `${gen.getIndent()}paintutils.drawFilledBox(${x1}, ${y1}, ${x2}, ${y2}, ${color})`;
         }
     },

--- a/src/renderer/engine/blockly/blocks/custom/terminal.ts
+++ b/src/renderer/engine/blockly/blocks/custom/terminal.ts
@@ -31,7 +31,7 @@ export const terminalBlocks: Blocks = {
         },
         generator: (block, gen) => {
             const text = gen.valueToCode(block, 'TEXT', Order.NONE);
-            return `${gen.getIndent()}term.print(${text})`;
+            return `${gen.getIndent()}print(${text})`;
         }
     },
     'term_redirect': {
@@ -61,7 +61,7 @@ export const terminalBlocks: Blocks = {
             },
         },
         generator: (block, gen) => {
-            return [`term.read()`, Order.ATOMIC];
+            return [`read()`, Order.ATOMIC];
         }
     },
     'term_clear': {
@@ -190,7 +190,7 @@ export const terminalBlocks: Blocks = {
             },
         },
         generator: (block, gen) => {
-            const n = gen.valueToCode(block, 'N', Order.NONE);
+            const n = gen.valueToCode(block, 'NUMBER', Order.NONE);
             return `${gen.getIndent()}term.scroll(${n})`;
         }
     },
@@ -211,10 +211,16 @@ export const terminalBlocks: Blocks = {
             },
         },
         generator: (block, gen) => {
-            const text = gen.valueToCode(block, 'TEXT', Order.NONE);
-            const fg = gen.valueToCode(block, 'FG', Order.NONE);
-            const bg = gen.valueToCode(block, 'BG', Order.NONE);
-            return `${gen.getIndent()}term.blit(${text}, ${fg}, ${bg})`;
+            const text = gen.valueToCode(block, 'TEXT', Order.NONE) || '""';
+            const fg = gen.valueToCode(block, 'FG', Order.NONE) || 'colors.white';
+            const bg = gen.valueToCode(block, 'BG', Order.NONE) || 'colors.black';
+            const map = `{[colors.white]="0",[colors.orange]="1",[colors.magenta]="2",[colors.lightBlue]="3",[colors.yellow]="4",[colors.lime]="5",[colors.pink]="6",[colors.gray]="7",[colors.lightGray]="8",[colors.cyan]="9",[colors.purple]="a",[colors.blue]="b",[colors.brown]="c",[colors.green]="d",[colors.red]="e",[colors.black]="f"}`;
+            return `${gen.getIndent()}do
+${gen.getIndent()}  local _blitText = tostring(${text})
+${gen.getIndent()}  local _fg = (${map})[${fg}] or "0"
+${gen.getIndent()}  local _bg = (${map})[${bg}] or "f"
+${gen.getIndent()}  term.blit(_blitText, string.rep(_fg, #_blitText), string.rep(_bg, #_blitText))
+${gen.getIndent()}end`;
         }
     },
     'term_getWidth': {
@@ -228,7 +234,7 @@ export const terminalBlocks: Blocks = {
             },
         },
         generator: (block, gen) => {
-            return [`({term.getSize()})`, Order.ATOMIC];
+            return [`select(1, term.getSize())`, Order.ATOMIC];
         }
     },
     'term_getHeight': {
@@ -256,7 +262,7 @@ export const terminalBlocks: Blocks = {
             },
         },
         generator: (block, gen) => {
-            return [`({term.getCursorPos()})`, Order.ATOMIC];
+            return [`select(1, term.getCursorPos())`, Order.ATOMIC];
         }
     },
     'term_getCursorY': {

--- a/src/renderer/engine/blockly/blocks/custom/window.ts
+++ b/src/renderer/engine/blockly/blocks/custom/window.ts
@@ -108,7 +108,7 @@ export const windowBlocks: Blocks = {
         },
         generator: (block, gen) => {
             const win = gen.valueToCode(block, 'WIN', Order.ATOMIC);
-            return [`({${win}.getSize()})`, Order.ATOMIC];
+            return [`select(1, ${win}.getSize())`, Order.ATOMIC];
         }
     },
     'window_getHeight': {
@@ -144,7 +144,7 @@ export const windowBlocks: Blocks = {
         },
         generator: (block, gen) => {
             const win = gen.valueToCode(block, 'WIN', Order.ATOMIC);
-            return [`({${win}.getPosition()})`, Order.ATOMIC];
+            return [`select(1, ${win}.getPosition())`, Order.ATOMIC];
         }
     },
     'window_getPositionY': {

--- a/src/renderer/engine/blockly/blocks/main/lists.ts
+++ b/src/renderer/engine/blockly/blocks/main/lists.ts
@@ -22,7 +22,7 @@ export const listsBlocks: Blocks = {
         generator: (block, gen) => {
             const list = gen.valueToCode(block, 'VALUE', Order.ATOMIC);
             const index = gen.valueToCode(block, 'AT', Order.NONE);
-            return [`${list}[${index}]`, Order.ATOMIC];
+            return [`(${list})[${index}]`, Order.ATOMIC];
         }
     }
 };


### PR DESCRIPTION

Fixes Lua generation for several block categories:

- terminal blocks: `print`, `read`, `scroll`, `get width`, `get cursor X`, `blit`
- list index block when used with inline lists
- paintutils draw blocks color input
- window width / position X getters

**Testing**
Block tested one by one manually 
and also tested by exporting CCraft projects and checking/running the generated Lua for each fixed block.
