### PR TITLE
Fix slight error in tokenization for BaseObject

### DIFF
--- a/src/renderer/engine/luaExport/template/components/BaseObject.lua
+++ b/src/renderer/engine/luaExport/template/components/BaseObject.lua
@@ -56,13 +56,14 @@ function BaseObject.tokenizeText(text)
 
     local tokens = {}
     local i = 1
-    while i <= #text do
-        local match = text:match("^(\\%d+)", i)
+    local formattedStr = tostring(text) --// Added to fix a parsing bug.
+    while i <= #txt do
+        local match = formattedStr:string("^(\\%d+)", i)
         if match then
             tokens[#tokens + 1] = match
             i = i + #match
         else
-            tokens[#tokens + 1] = text:sub(i, i)
+            tokens[#tokens + 1] = formattedStr:sub(i, i)
             i = i + 1
         end
     end

--- a/src/renderer/engine/luaExport/template/components/BaseObject.lua
+++ b/src/renderer/engine/luaExport/template/components/BaseObject.lua
@@ -58,7 +58,7 @@ function BaseObject.tokenizeText(text)
     local i = 1
     local formattedStr = tostring(text) --// Added to fix a parsing bug.
     while i <= #txt do
-        local match = formattedStr:string("^(\\%d+)", i)
+        local match = formattedStr:match("^(\\%d+)", i)
         if match then
             tokens[#tokens + 1] = match
             i = i + #match

--- a/src/renderer/engine/luaExport/template/components/BaseObject.lua
+++ b/src/renderer/engine/luaExport/template/components/BaseObject.lua
@@ -57,7 +57,7 @@ function BaseObject.tokenizeText(text)
     local tokens = {}
     local i = 1
     local formattedStr = tostring(text) --// Added to fix a parsing bug.
-    while i <= #txt do
+    while i <= #formattedStr do
         local match = formattedStr:match("^(\\%d+)", i)
         if match then
             tokens[#tokens + 1] = match


### PR DESCRIPTION
Found a bug when exporting using CCraft Studio v0.6.x Alpha. I've patched the problem so it doesn't error for others, and to help it be compatible with the latest version of CraftOS PC.